### PR TITLE
Make IE Happier in Contexts Where There Are No Statements

### DIFF
--- a/scripts/TinCanViewer.js
+++ b/scripts/TinCanViewer.js
@@ -527,10 +527,10 @@ TINCAN.Viewer.prototype.renderStatements = function(statementsResult){
 
 
 
+        var stmtStr = [];
 	for (i = 0; i < statements.length ; i++){
 		var stmt = statements[i];
 		try {
-            var stmtStr = [];
 			stmtStr.push("<tr class='statementRow'>");  
 			stmtStr.push("<td class='date'><div class='statementDate'>"+ stmt.stored.replace('Z','')  +"</div></td>");
 


### PR DESCRIPTION
IE doesn't much like it when an object is declared inside a loop and then referenced without a value. Chokes up in contexts with no statements.
