### PR TITLE
Stop displaying more button when first page exhausts stream.

### DIFF
--- a/scripts/TinCanQueryUtils.js
+++ b/scripts/TinCanQueryUtils.js
@@ -138,7 +138,7 @@ TINCAN.MultiLRSStatementStream.prototype = {
                     // returned if there are no more results to fetch... but
                     // all the code here checks for null explicitly. So "cast"
                     // empty string results as null.
-                    streamState.moreUrl = stResult.more ? stResult.more : null;
+                    streamState.moreUrl = stResult.more === "" ? null : stResult.more;
                 }
 
                 // Only do handed in callback after all versions done

--- a/scripts/TinCanQueryUtils.js
+++ b/scripts/TinCanQueryUtils.js
@@ -134,7 +134,11 @@ TINCAN.MultiLRSStatementStream.prototype = {
                 if (err === null) {
                     // Capture this lrs's statements into state, note more url
                     Array.prototype.push.apply(streamState.statements, stResult.statements);
-                    streamState.moreUrl = stResult.more;
+                    // The spec stipulates that an empty string should be
+                    // returned if there are no more results to fetch... but
+                    // all the code here checks for null explicitly. So "cast"
+                    // empty string results as null.
+                    streamState.moreUrl = stResult.more ? stResult.more : null;
                 }
 
                 // Only do handed in callback after all versions done


### PR DESCRIPTION
I did not realize I didn't have a private fork of this, so I pushed the branch here. Sorry about that—just delete the branch after this PR is merged.

Anyways, a customer is trying to embed statement viewer, and they noticed a bug: if for some reason we receive less than a page of statements, the "more" button would still show up. It turns out this is because the check that determines whether the more button should be visible was checking that the more URL was equal to null, but we were getting an empty string back from the LRS (which is exactly what we expect). But since the more URL was just an empty string, it couldn't be parsed correctly by TinCanJS down the line and would throw an error.

Since there were several places that were checking the more url property for null, it made more sense just to set the LRSState object's `more` property to null if there was no `more` URL.