### PR TITLE
Changed URL for TinCanJS submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "scripts/TinCanJS"]
 	path = scripts/TinCanJS
-	url = git://github.com/RusticiSoftware/TinCanJS.git
+	url = https://github.com/RusticiSoftware/TinCanJS.git


### PR DESCRIPTION
Since GitHub will stop allowing the unauthenticated 'git://' URL by March 15, 2022 (see [this article](https://github.blog/2021-09-01-improving-git-protocol-security-github/), we need to update this URL so that the tool can still get the TinCanJS submodule and build correctly.